### PR TITLE
Handle workflow graph cycles gracefully

### DIFF
--- a/tests/test_pack_loader.py
+++ b/tests/test_pack_loader.py
@@ -26,3 +26,12 @@ def test_topological_order_matches_node_count() -> None:
     order = pack_loader.topological_order(nodes, edges)
     assert order == ["a", "b", "c"]
 
+
+def test_cli_reports_cycle(project_root: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = pack_loader.main([str(project_root)])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "quality_feedback" in output
+    assert "Warning: Workflow graph contains a cycle involving" in output
+


### PR DESCRIPTION
## Summary
- detect workflow graph cycles when summarising workflow graphs and turn them into readable warnings
- ensure the CLI can report partial execution orders for cyclic graphs instead of crashing
- add a regression test that runs the CLI on the quality_feedback workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d154d1f56883248ccc541ca06119c9